### PR TITLE
Feat: RestControllerAdvice 활용한 response 객체 생성 위임 (#7)

### DIFF
--- a/src/main/java/com/flab/dduikka/common/domain/Auditable.java
+++ b/src/main/java/com/flab/dduikka/common/domain/Auditable.java
@@ -1,4 +1,4 @@
-package com.flab.dduikka.domain;
+package com.flab.dduikka.common.domain;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/flab/dduikka/common/handler/GlobalResponseHandler.java
+++ b/src/main/java/com/flab/dduikka/common/handler/GlobalResponseHandler.java
@@ -1,0 +1,30 @@
+package com.flab.dduikka.common.handler;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@RestControllerAdvice
+public class GlobalResponseHandler implements ResponseBodyAdvice<Object> {
+	@Override
+	public boolean supports(MethodParameter returnType, Class converterType) {
+		return !converterType.equals(StringHttpMessageConverter.class);
+	}
+
+	@Override
+	public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+		Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+		HttpServletResponse servletResponse =
+			((ServletServerHttpResponse)response).getServletResponse();
+		return ResponseEntity.status(servletResponse.getStatus())
+			.body(body);
+	}
+}

--- a/src/main/java/com/flab/dduikka/domain/login/api/LoginController.java
+++ b/src/main/java/com/flab/dduikka/domain/login/api/LoginController.java
@@ -1,8 +1,9 @@
 package com.flab.dduikka.domain.login.api;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.dduikka.domain.login.application.LoginService;
@@ -22,25 +23,23 @@ public class LoginController {
 	private final LoginService loginService;
 
 	@PostMapping("/login")
-	public ResponseEntity<Void> login(@Valid @RequestBody LoginRequestDto loginRequestDto, HttpServletRequest request) {
+	@ResponseStatus(HttpStatus.OK)
+	public void login(@Valid @RequestBody LoginRequestDto loginRequestDto, HttpServletRequest request) {
 		SessionMember sessionMember = loginService.login(loginRequestDto);
 		if (sessionMember == null) {
 			throw new LoginException.FailLoginException("찾을 수 없는 회원입니다.");
 		}
 		HttpSession session = request.getSession(true);
 		session.setAttribute(SessionKey.LOGIN_USER.name(), sessionMember);
-		return ResponseEntity.ok()
-			.build();
 	}
 
 	@PostMapping("/logout")
-	public ResponseEntity<Void> logout(HttpServletRequest request) {
+	@ResponseStatus(HttpStatus.OK)
+	public void logout(HttpServletRequest request) {
 		HttpSession session = request.getSession(false);
 		if (session == null) {
 			throw new IllegalStateException("유효하지 않은 요청입니다.");
 		}
 		session.invalidate();
-		return ResponseEntity.ok()
-			.build();
 	}
 }

--- a/src/main/java/com/flab/dduikka/domain/member/api/MemberController.java
+++ b/src/main/java/com/flab/dduikka/domain/member/api/MemberController.java
@@ -1,8 +1,6 @@
 package com.flab.dduikka.domain.member.api;
 
-import java.net.URI;
-
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -10,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.dduikka.domain.member.application.MemberService;
@@ -29,30 +28,27 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@GetMapping("/{memberId}")
-	public ResponseEntity<MemberResponseDto> findMember(@PathVariable final long memberId) {
-		MemberResponseDto foundMember = memberService.findMember(memberId);
-		return ResponseEntity.ok()
-			.body(foundMember);
+	@ResponseStatus(HttpStatus.OK)
+	public MemberResponseDto findMember(@PathVariable final long memberId) {
+		return memberService.findMember(memberId);
 	}
 
 	@GetMapping("/{email}/duplicated")
-	public ResponseEntity<Boolean> isEmailDuplicated(@PathVariable @Email final String email) {
-		boolean response = memberService.isEmailDuplicated(email);
-		return ResponseEntity.ok()
-			.body(response);
+	@ResponseStatus(HttpStatus.OK)
+	public Boolean isEmailDuplicated(@PathVariable @Email final String email) {
+		return memberService.isEmailDuplicated(email);
 	}
 
 	@PostMapping
-	public ResponseEntity<Void> registerMember(@RequestBody @Valid MemberRegisterRequestDto request) {
+	@ResponseStatus(HttpStatus.CREATED)
+	public void registerMember(@RequestBody @Valid MemberRegisterRequestDto request) {
 		memberService.registerMember(request);
-		return ResponseEntity.created(URI.create("/login")).build();
 	}
 
 	@PatchMapping("/{memberId}")
-	public ResponseEntity<Void> leaveMember(@PathVariable final long memberId) {
+	@ResponseStatus(HttpStatus.OK)
+	public void leaveMember(@PathVariable final long memberId) {
 		memberService.leaveMember(memberId);
-		return ResponseEntity.ok()
-			.build();
 	}
 
 }

--- a/src/main/java/com/flab/dduikka/domain/member/domain/Member.java
+++ b/src/main/java/com/flab/dduikka/domain/member/domain/Member.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import com.flab.dduikka.domain.Auditable;
+import com.flab.dduikka.common.domain.Auditable;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/flab/dduikka/domain/vote/api/VoteController.java
+++ b/src/main/java/com/flab/dduikka/domain/vote/api/VoteController.java
@@ -1,15 +1,15 @@
 package com.flab.dduikka.domain.vote.api;
 
-import java.net.URI;
 import java.time.LocalDate;
 
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.dduikka.domain.vote.application.VoteRecordService;
@@ -28,33 +28,28 @@ public class VoteController {
 	private final VoteRecordService voteRecordService;
 
 	@GetMapping("/{voteDate}")
-	public ResponseEntity<VoteResponseDto> findVote(@PathVariable final LocalDate voteDate) {
-		VoteResponseDto voteResponseDto = voteRecordService.findVoteTypeCount(voteDate);
-		return ResponseEntity.ok()
-			.body(voteResponseDto);
+	@ResponseStatus(HttpStatus.OK)
+	public VoteResponseDto findVote(@PathVariable final LocalDate voteDate) {
+		return voteRecordService.findVoteTypeCount(voteDate);
 	}
 
 	// TODO: USER 구현 후 userId 가져오는 방법 추가
 	@GetMapping("/record/{voteId}")
-	public ResponseEntity<VoteRecordResponseDto> findUserVoteRecord(@PathVariable final long voteId) {
+	@ResponseStatus(HttpStatus.OK)
+	public VoteRecordResponseDto findUserVoteRecord(@PathVariable final long voteId) {
 		long userId = 1L;
-		VoteRecordResponseDto voteRecordResponseDto = voteRecordService
-			.findUserVoteRecord(userId, voteId);
-		return ResponseEntity.ok()
-			.body(voteRecordResponseDto);
+		return voteRecordService.findUserVoteRecord(userId, voteId);
 	}
 
 	@PostMapping("/record")
-	public ResponseEntity<Void> addVoteRecord(@RequestBody @Valid final VoteRecordAddRequestDto request) {
+	@ResponseStatus(HttpStatus.CREATED)
+	public void addVoteRecord(@RequestBody @Valid final VoteRecordAddRequestDto request) {
 		voteRecordService.addVoteRecord(request);
-		return ResponseEntity.created(URI.create("/vote/record/" + LocalDate.now()))
-			.build();
 	}
 
 	@PatchMapping("/record/{voteRecordId}")
-	public ResponseEntity<Void> cancelVoteRecord(@PathVariable final long voteRecordId) {
+	@ResponseStatus(HttpStatus.OK)
+	public void cancelVoteRecord(@PathVariable final long voteRecordId) {
 		voteRecordService.cancelVoteRecord(voteRecordId);
-		return ResponseEntity.ok()
-			.build();
 	}
 }

--- a/src/main/java/com/flab/dduikka/domain/vote/domain/Vote.java
+++ b/src/main/java/com/flab/dduikka/domain/vote/domain/Vote.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-import com.flab.dduikka.domain.Auditable;
+import com.flab.dduikka.common.domain.Auditable;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;

--- a/src/main/java/com/flab/dduikka/domain/vote/domain/VoteRecord.java
+++ b/src/main/java/com/flab/dduikka/domain/vote/domain/VoteRecord.java
@@ -2,7 +2,7 @@ package com.flab.dduikka.domain.vote.domain;
 
 import java.time.LocalDateTime;
 
-import com.flab.dduikka.domain.Auditable;
+import com.flab.dduikka.common.domain.Auditable;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/flab/dduikka/domain/vote/dto/VoteRecordAddRequestDto.java
+++ b/src/main/java/com/flab/dduikka/domain/vote/dto/VoteRecordAddRequestDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import com.flab.dduikka.domain.vote.domain.VoteRecord;
 import com.flab.dduikka.domain.vote.domain.VoteType;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,11 +14,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
 public class VoteRecordAddRequestDto {
 
-	@NotBlank(message = "voteId null 일 수 없습니다.")
+	@NotNull(message = "voteId null 일 수 없습니다.")
 	private final long voteId;
-	@NotBlank(message = "userId null 일 수 없습니다.")
+	@NotNull(message = "userId null 일 수 없습니다.")
 	private final long userId;
-	@NotBlank(message = "voteType null 일 수 없습니다.")
+	@NotNull(message = "voteType null 일 수 없습니다.")
 	private final VoteType voteType;
 	private final boolean isCanceled;
 

--- a/src/test/java/com/flab/dduikka/domain/vote/api/VoteDocumentationTest.java
+++ b/src/test/java/com/flab/dduikka/domain/vote/api/VoteDocumentationTest.java
@@ -51,10 +51,13 @@ class VoteDocumentationTest extends ApiDocumentationHelper {
 				preprocessResponse(prettyPrint()),
 				pathParameters(parameterWithName("voteDate").description("투표일자")),
 				responseFields(
-					fieldWithPath("voteId").description("투표번호")   // 필드 설명 snippets 생성
-					, fieldWithPath("voteDate").description("투표일자")
-					, fieldWithPath("voteTypeCountMap.*").type(JsonFieldType.VARIES)
-						.description("투표타입별 투표수 맵 - (VoteType : Integer)")
+					fieldWithPath("headers").description("헤더라인"),
+					fieldWithPath("body.voteId").description("투표번호"),   // 필드 설명 snippets 생성
+					fieldWithPath("body.voteDate").description("투표일자"),
+					fieldWithPath("body.voteTypeCountMap.*").type(JsonFieldType.VARIES)
+						.description("투표타입별 투표수 맵 - (VoteType : Integer)"),
+					fieldWithPath("statusCode").description("결과코드"),
+					fieldWithPath("statusCodeValue").description("결과값")
 				)))
 			.andExpect(status().isOk());
 	}
@@ -76,9 +79,12 @@ class VoteDocumentationTest extends ApiDocumentationHelper {
 				preprocessResponse(prettyPrint()),
 				pathParameters(parameterWithName("voteId").description("투표번호")),
 				responseFields(
-					fieldWithPath("voteRecordId").description("투표기록번호")   // 필드 설명 snippets 생성
-					, fieldWithPath("voteId").description("투표번호")
-					, voteTypeFiled()
+					fieldWithPath("headers").description("헤더라인"),
+					fieldWithPath("body.voteRecordId").description("투표기록번호"),   // 필드 설명 snippets 생성
+					fieldWithPath("body.voteId").description("투표번호"),
+					voteTypeFiled("body.voteType"),
+					fieldWithPath("statusCode").description("결과코드"),
+					fieldWithPath("statusCodeValue").description("결과값")
 				)))
 			.andExpect(status().isOk());
 	}
@@ -100,13 +106,11 @@ class VoteDocumentationTest extends ApiDocumentationHelper {
 				preprocessRequest(prettyPrint()),
 				preprocessResponse(prettyPrint()),
 				requestFields(
-					fieldWithPath("voteId").description("투표번호")
-					, fieldWithPath("userId").description("유저번호")
-					, voteTypeFiled()
+					fieldWithPath("voteId").description("투표번호"),
+					fieldWithPath("userId").description("유저번호"),
+					voteTypeFiled("voteType")
 				)))
-			.andExpect(status().isCreated())
-			.andExpect(header().string("Location", "/vote/record/" + LocalDate.now())) //질문
-			.andExpect(redirectedUrl("/vote/record/" + LocalDate.now()));
+			.andExpect(status().isCreated());
 	}
 
 	@Test
@@ -122,11 +126,11 @@ class VoteDocumentationTest extends ApiDocumentationHelper {
 			.andExpect(status().isOk());
 	}
 
-	private FieldDescriptor voteTypeFiled() {
+	private FieldDescriptor voteTypeFiled(String fieldPath) {
 		String formattedEnumValues = Arrays.stream(VoteType.values())
 			.map(type -> String.format("`%s`", type))
 			.collect(Collectors.joining(", "));
-		return fieldWithPath("voteType").description("투표 타입 상세 : " + formattedEnumValues);
+		return fieldWithPath(fieldPath).description("투표 타입 상세 : " + formattedEnumValues);
 	}
 
 }


### PR DESCRIPTION
### [세부사항]
- RestControllerAdvice와 ResponseBodyAdvice를 구현한 공통 응답 핸들러를 생성하였습니다.
- 각 RestController에서 ResponseEntity를 생성하던 책임을 위임하였습니다.