### PR TITLE
Feat: logging filter 적용

### DIFF
--- a/src/main/java/com/flab/dduikka/common/filter/LoggingFilter.java
+++ b/src/main/java/com/flab/dduikka/common/filter/LoggingFilter.java
@@ -1,0 +1,61 @@
+package com.flab.dduikka.common.filter;
+
+import static com.flab.dduikka.common.util.LogFormatter.*;
+
+import java.io.IOException;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class LoggingFilter implements Filter {
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		Filter.super.init(filterConfig);
+	}
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws
+		IOException {
+
+		ContentCachingRequestWrapper httpServletRequest =
+			new ContentCachingRequestWrapper((HttpServletRequest)servletRequest);
+		ContentCachingResponseWrapper httpServletResponse =
+			new ContentCachingResponseWrapper((HttpServletResponse)servletResponse);
+
+		long startTime = System.nanoTime();
+
+		try {
+			logRequest(httpServletRequest);
+			filterChain.doFilter(httpServletRequest, httpServletResponse);
+
+		} catch (Exception e) {
+			log.error("{}", e.getMessage());
+		} finally {
+			long endTime = System.nanoTime();
+			logResponse(httpServletResponse, (endTime - startTime) / 1_000_000_000.0);
+			httpServletResponse.copyBodyToResponse();
+		}
+	}
+
+	@Override
+	public void destroy() {
+		Filter.super.destroy();
+	}
+}

--- a/src/main/java/com/flab/dduikka/common/filter/LoggingFilter.java
+++ b/src/main/java/com/flab/dduikka/common/filter/LoggingFilter.java
@@ -1,6 +1,6 @@
 package com.flab.dduikka.common.filter;
 
-import static com.flab.dduikka.common.util.LogFormatter.*;
+import static com.flab.dduikka.common.util.HttpRequestResponseLogger.*;
 
 import java.io.IOException;
 

--- a/src/main/java/com/flab/dduikka/common/util/HttpRequestResponseLogger.java
+++ b/src/main/java/com/flab/dduikka/common/util/HttpRequestResponseLogger.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class LogFormatter {
+public class HttpRequestResponseLogger {
 	public static void logRequest(ContentCachingRequestWrapper request) {
 		log.info("Request HTTPMethod = [{}], RequestURI = [{}]", request.getMethod(), request.getRequestURI());
 		log.info("IP = [{}]", request.getRemoteAddr());

--- a/src/main/java/com/flab/dduikka/common/util/LogFormatter.java
+++ b/src/main/java/com/flab/dduikka/common/util/LogFormatter.java
@@ -1,0 +1,30 @@
+package com.flab.dduikka.common.util;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LogFormatter {
+	public static void logRequest(ContentCachingRequestWrapper request) {
+		log.info("Request HTTPMethod = [{}], RequestURI = [{}]", request.getMethod(), request.getRequestURI());
+		log.info("IP = [{}]", request.getRemoteAddr());
+	}
+
+	public static void logResponse(ContentCachingResponseWrapper response, double elapsedTime) {
+		String responseBody = new String(response.getContentAsByteArray());
+		if (response.getContentAsByteArray().length > 0) {
+			log.info("Response: responseStatus = [{}], responseBody = [{}] ",
+				HttpStatus.valueOf(response.getStatus()).name(),
+				responseBody);
+		} else {
+			log.info("Response: responseStatus = [{}] ", HttpStatus.valueOf(response.getStatus()).name());
+		}
+		log.info("elapsedTime = {}", elapsedTime);
+	}
+}


### PR DESCRIPTION
### [세부사항]
- HttpServlet request와 response에 대한 logging을 적용하였습니다.
- HttpServletRequest가 요청을 두 번 읽을 수 없는 이슈로 `ContentCachingRequestWrapper` 클래스로 한 번 더 wrapping 하였습니다.
- HttpRequestResponseLogger 유틸 클래스에서 요청과 응답의 logging 기능을 수행하도록 하였습니다.
- local에서는 console에 작성할 예정이고 prod 환경에서는 파일에 작성되도록 추후 변경할 예정입니다. (질문 예정..)