### PR TITLE
Fix: processResource task 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,28 +118,6 @@ bootJar {
     dependsOn copyDocument
 }
 
-// build 시 Hello world!를 출력하는 other task
-tasks.register('helloTask') {
-    // task chaining : task 작업 실행 순서를 지정할 때 사용된다.
-    dependsOn superTask // superTask -> helloTask
-    finalizedBy subTask // helloTask -> subTask
-//	println 'Do onConfiguration' // Configuration 단계에서 수행
-    doFirst { // task 목록 시작에 추가한다.
-        println 'hello print first' // Execution 단계에서 수행
-    }
-    doLast { // task 목록 끝에 추가한다.
-        println 'hello print last'
-    }
-}
-
-tasks.register('superTask') {
-    doFirst {
-        println 'superTask'
-    }
-}
-
-tasks.register('subTask') {
-    doFirst {
-        println 'subTask'
-    }
+tasks.processResources {
+    dependsOn copyDocument
 }


### PR DESCRIPTION
### 세부내용
**1. 프로젝트 build 시 task 간 의존성 오류 수정**
- `processResources` task 실행 시 `src/resource -> build/resource`로 이동하게 되는데 `copyDocument`가 실행되어야만 resource에 파일이 생성됩니다. 이로 인해 의존성 오류가 발생하여 build가 실패하는 문제로 수정하게 되었습니다.

**2. 불필요한 build task 제거**