### PR TITLE
Fix: equals, hashcode 기준 필드 변경

### DIFF
--- a/src/main/java/com/flab/dduikka/common/domain/Auditable.java
+++ b/src/main/java/com/flab/dduikka/common/domain/Auditable.java
@@ -1,7 +1,6 @@
 package com.flab.dduikka.common.domain;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -14,20 +13,5 @@ public abstract class Auditable {
 
 	protected Auditable(LocalDateTime createdAt) {
 		this.createdAt = createdAt;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		Auditable auditable = (Auditable)o;
-		return Objects.equals(createdAt, auditable.createdAt);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(createdAt);
 	}
 }

--- a/src/main/java/com/flab/dduikka/domain/livechat/domain/LiveChat.java
+++ b/src/main/java/com/flab/dduikka/domain/livechat/domain/LiveChat.java
@@ -52,16 +52,14 @@ public class LiveChat extends Auditable {
 			return true;
 		if (o == null || getClass() != o.getClass())
 			return false;
-		if (!super.equals(o))
-			return false;
 		LiveChat liveChat = (LiveChat)o;
-		return liveChatId == liveChat.liveChatId && memberId == liveChat.memberId && deletedFlag
-			== liveChat.deletedFlag;
+		return liveChatId == liveChat.liveChatId && memberId == liveChat.memberId && deletedFlag == liveChat.deletedFlag
+			&& Objects.equals(message, liveChat.message);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(liveChatId, memberId, deletedFlag);
+		return Objects.hash(liveChatId, memberId, message, deletedFlag);
 	}
 
 	@Override

--- a/src/main/java/com/flab/dduikka/domain/member/domain/Member.java
+++ b/src/main/java/com/flab/dduikka/domain/member/domain/Member.java
@@ -60,12 +60,12 @@ public class Member extends Auditable {
 		if (o == null || getClass() != o.getClass())
 			return false;
 		Member member = (Member)o;
-		return memberId == member.memberId && Objects.equals(email, member.email)
-			&& memberStatus == member.memberStatus && Objects.equals(joinDate, member.joinDate);
+		return memberId == member.memberId && Objects.equals(email, member.email) && Objects.equals(
+			password, member.password) && memberStatus == member.memberStatus;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(memberId);
+		return Objects.hash(memberId, email, password, memberStatus);
 	}
 }

--- a/src/main/java/com/flab/dduikka/domain/vote/domain/VoteRecord.java
+++ b/src/main/java/com/flab/dduikka/domain/vote/domain/VoteRecord.java
@@ -1,6 +1,7 @@
 package com.flab.dduikka.domain.vote.domain;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import com.flab.dduikka.common.domain.Auditable;
 
@@ -20,10 +21,6 @@ public class VoteRecord extends Auditable {
 
 	private Boolean isCanceled;
 
-	private VoteRecord(LocalDateTime createdAt) {
-		super(createdAt);
-	}
-
 	@Builder
 	public VoteRecord(Long voteRecordId, Long voteId, Long userId, VoteType voteType, boolean isCanceled,
 		LocalDateTime createdAt) {
@@ -33,6 +30,23 @@ public class VoteRecord extends Auditable {
 		this.userId = userId;
 		this.voteType = voteType;
 		this.isCanceled = isCanceled;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		VoteRecord that = (VoteRecord)o;
+		return Objects.equals(voteRecordId, that.voteRecordId) && Objects.equals(voteId, that.voteId)
+			&& Objects.equals(userId, that.userId) && voteType == that.voteType && Objects.equals(
+			isCanceled, that.isCanceled);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(voteRecordId, voteId, userId, voteType, isCanceled);
 	}
 
 	public void cancel() {

--- a/src/test/java/com/flab/dduikka/domain/vote/repository/JdbcVoteRecordRepositoryTest.java
+++ b/src/test/java/com/flab/dduikka/domain/vote/repository/JdbcVoteRecordRepositoryTest.java
@@ -33,7 +33,7 @@ class JdbcVoteRecordRepositoryTest extends JDBCRepositoryTestHelper {
 		//then
 		VoteRecord foundVoteRecord = voteRecordRepository
 			.findByUserAndVoteAndIsCanceled(1L, 1L).get();
-		assertThat(foundVoteRecord.getVoteType()).isEqualTo(newVote.getVoteType());
+		assertThat(foundVoteRecord).isEqualTo(createdVote);
 	}
 
 	@Test
@@ -53,7 +53,7 @@ class JdbcVoteRecordRepositoryTest extends JDBCRepositoryTestHelper {
 			.findByUserAndVoteAndIsCanceled(1L, 1L).get();
 
 		//then
-		assertThat(foundVoteRecord.getVoteType()).isEqualTo(newVote.getVoteType());
+		assertThat(foundVoteRecord).isEqualTo(createdVote);
 	}
 
 	@Test
@@ -109,8 +109,7 @@ class JdbcVoteRecordRepositoryTest extends JDBCRepositoryTestHelper {
 			.get();
 
 		// then
-		assertThat(foundVoteRecord.getVoteId()).isEqualTo(createdVoteRecord.getVoteId());
-		assertThat(foundVoteRecord.getCreatedAt()).isEqualTo(createdVoteRecord.getCreatedAt());
+		assertThat(foundVoteRecord).isEqualTo(createdVoteRecord);
 	}
 
 	@Test


### PR DESCRIPTION
[세부내용]
- `createdAt` 필드가 linux 환경에서 나노초 기준이고 DB에 저장된 이후 createdAt은 밀리초 기준이라 linux 환경에서 test 시 서로 다른 객체 주소를 가지는 문제가 발생하였습니다. 이로 인하여 불필요한 기준 필드를 제거하고 애플리케이션 라이프사이클에 맞도록 `EqualsAndHashCode`를 재검토하였습니다.

**[변경내용]**
- `EqualsAndHashCode` 기준 필드 및 테스트 비교 기준을 변경하였습니다.