### PR TITLE
Refactor: 익명 채팅 식별자 캐싱 구현체 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     // Spring MVC를 사용하여 RESTful, 애플리케이션을 포함한 스타터. Tomcat을 내장 컨테이너로 사용한다.
     implementation 'org.springframework.boot:spring-boot-starter-validation' // spring validation 검증 라이브러리
     implementation 'org.springframework.boot:spring-boot-starter-jdbc' // jdbc 커넥터
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.awaitility:awaitility:4.2.0'
     runtimeOnly 'com.h2database:h2' // h2 database
     runtimeOnly 'com.mysql:mysql-connector-j:8.4.0' // mysql용 jdbc 타입 드라이버
@@ -61,6 +60,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test' // Spring Boot 애플리케이션 테스트 스타터
     implementation 'org.springframework.security:spring-security-crypto:6.3.0'
+
+    //cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation "com.github.ben-manes.caffeine:caffeine:3.1.8"
 
     //테스트에서 lombok 사용
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/flab/dduikka/common/domain/CacheType.java
+++ b/src/main/java/com/flab/dduikka/common/domain/CacheType.java
@@ -1,0 +1,18 @@
+package com.flab.dduikka.common.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheType {
+	MEMBERIDENTIFIER_CACHE(0, 500, 10 * 60);
+
+	private final int expireAfterWrite;
+	private final int maximumSize;
+	private final int expireAfterAccess;
+
+	CacheType(int expireAfterWrite, int maximumSize, int expireAfterAccess) {
+		this.expireAfterWrite = expireAfterWrite;
+		this.maximumSize = maximumSize;
+		this.expireAfterAccess = expireAfterAccess;
+	}
+}

--- a/src/main/java/com/flab/dduikka/common/encryption/EncryptedMemberIdentifierCache.java
+++ b/src/main/java/com/flab/dduikka/common/encryption/EncryptedMemberIdentifierCache.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class EncryptedMemberIdentifierCache {
 
-	@Cacheable(value = "MemberIdentifier")
+	@Cacheable(value = "MEMBERIDENTIFIER_CACHE")
 	public String cacheEncryptedMemberIdentifier(String data) {
 		return SHA256Encryptor.hashSHA256(data);
 	}

--- a/src/main/java/com/flab/dduikka/config/CacheConfig.java
+++ b/src/main/java/com/flab/dduikka/config/CacheConfig.java
@@ -1,16 +1,32 @@
 package com.flab.dduikka.config;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.flab.dduikka.common.domain.CacheType;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 @EnableCaching
 @Configuration
 public class CacheConfig {
 	@Bean
 	public CacheManager cacheManager() {
-		return new ConcurrentMapCacheManager("MemberIdentifier");
+		List<CaffeineCache> caffeineCaches = Arrays.stream(CacheType.values())
+			.map(cache -> new CaffeineCache(cache.name(), Caffeine.newBuilder().recordStats()
+				.expireAfterAccess(cache.getExpireAfterAccess(), TimeUnit.SECONDS)
+				.maximumSize(cache.getMaximumSize())
+				.build()))
+			.toList();
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		cacheManager.setCaches(caffeineCaches);
+		return cacheManager;
 	}
 }

--- a/src/test/java/com/flab/dduikka/common/encryption/SHA256EncryptorTest.java
+++ b/src/test/java/com/flab/dduikka/common/encryption/SHA256EncryptorTest.java
@@ -2,8 +2,6 @@ package com.flab.dduikka.common.encryption;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -22,22 +20,6 @@ class SHA256EncryptorTest {
 			String currentHash = SHA256Encryptor.hashSHA256(password);
 			assertThat(initialHash).isEqualTo(currentHash);
 		}
-	}
-
-	@Test
-	@DisplayName("암호화 수행시간이 1초 이하인지 검증한다")
-	void testSHA256Performance() {
-		//given
-		int loopCnt = 50;
-		String data = "1234567";
-		long startTime = System.nanoTime();
-		//when
-		for (int i = 0; i < loopCnt; i++)
-			SHA256Encryptor.hashSHA256(data);
-		long latency = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startTime);
-		log.info("Test execute Time : {}", latency);
-		//then
-		assertThat(latency).isLessThanOrEqualTo(1);
 	}
 
 }


### PR DESCRIPTION
### [세부내용]
- 스프링 캐시 구현체를 `ConcurrentMap`에서 `CaffeineCache`로 변경하였습니다. 이전에 캐시 정책이 없어, 메모리에 지속적으로 데이터가 적재된다는 문제점이 있었습니다.
- `EhCache`가 GC 대상도 제외되고 디스크에도 저장할 수 있다는 장점이 있지만 단순히 캐시만을 위한 용도로는 `CaffeineCache`가 수행 속도가 좋다는 벤치마크가 있어 `CaffeineCache`으로 결정하였습니다. `Redis`를 고려하지 않은 이유는 `Redis` 서버를 별도로 구축해야하고 Cache의 key 값이 변경되지 않으며(scale out 시 서버 간 정합성 문제 발생 낮음) 네트워크 i/o 비용이 들지 않는 로컬 캐시로 결정하였습니다.