### PR TITLE
Feat: geohash 라이브러리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ dependencies {
 
     //jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    //geohash
+    implementation 'ch.hsr:geohash:1.4.0'
 }
 
 dependencyManagement {

--- a/src/main/java/com/flab/dduikka/common/util/GeoHashUtil.java
+++ b/src/main/java/com/flab/dduikka/common/util/GeoHashUtil.java
@@ -1,0 +1,20 @@
+package com.flab.dduikka.common.util;
+
+import ch.hsr.geohash.GeoHash;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class GeoHashUtil {
+
+	public String getGeoHashString(String latitude, String longitude) {
+		GeoHash geoHash =
+			GeoHash.withCharacterPrecision(Double.parseDouble(latitude), Double.parseDouble(longitude), 7);
+		return geoHash.toBase32();
+	}
+
+	public String getGeoHashString(String latitude, String longitude, int lengthOfHash) {
+		GeoHash geoHash =
+			GeoHash.withCharacterPrecision(Double.parseDouble(latitude), Double.parseDouble(longitude), lengthOfHash);
+		return geoHash.toBase32();
+	}
+}

--- a/src/main/java/com/flab/dduikka/domain/weather/application/WeatherService.java
+++ b/src/main/java/com/flab/dduikka/domain/weather/application/WeatherService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.flab.dduikka.common.util.GeoHashUtil;
 import com.flab.dduikka.domain.weather.client.WeatherClient;
 import com.flab.dduikka.domain.weather.domain.Weather;
 import com.flab.dduikka.domain.weather.dto.WeatherRequestDTO;
@@ -38,7 +39,7 @@ public class WeatherService {
 	}
 
 	public WeatherResponseDTO findWeather(WeatherRequestDTO request) {
-		String geoHash = pointToGeoHash(request.getLatitude(), request.getLongitude());
+		String geoHash = GeoHashUtil.getGeoHashString(request.getLatitude(), request.getLongitude());
 		Weather foundWeather = weatherRepository.findWeatherById(geoHash).orElseThrow(
 			() -> new WeatherException.WeatherNotFoundException("해당 위치에 대한 날씨가 존재하지 않습니다. weatherId: " + geoHash));
 		return WeatherResponseDTO.from(foundWeather);
@@ -65,10 +66,5 @@ public class WeatherService {
 	 */
 	private LocalDateTime advanceForecastRequestTime(LocalDateTime requestTime) {
 		return requestTime.minusMinutes(advanceMinutes);
-	}
-
-	//TODO : weather API 갱신하기 구현 시에 geohash 값 얻어오도록 함
-	private String pointToGeoHash(String latitude, String longitude) {
-		return "geohash temp";
 	}
 }

--- a/src/test/java/com/flab/dduikka/common/util/GeoHashUtilTest.java
+++ b/src/test/java/com/flab/dduikka/common/util/GeoHashUtilTest.java
@@ -1,0 +1,27 @@
+package com.flab.dduikka.common.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class GeoHashUtilTest {
+
+	@Test
+	@DisplayName("위경도를 통해 geohash 값을 조회한다.")
+	void whenGetGeoHashString_thenReturnGeoHashString() {
+		// given
+		String latitude = "55.1";
+		String longitude = "127.32";
+
+		// when
+		String geoHashString = GeoHashUtil.getGeoHashString(latitude, longitude);
+		log.info("geoHashString = {}", GeoHashUtil.getGeoHashString(latitude, longitude));
+
+		// then
+		assertThat(geoHashString).isNotNull();
+	}
+}


### PR DESCRIPTION
### [세부내용]
- 단순 위경도가 아닌 위경도 범위값을 조회하기 위해 geohash를 사용하였습니다. mysql의 geohash 함수는 DB 종속적이고 redis는 서버 구성이 필요하며 주변값이 필요하지 않아서 라이브러리를 활용하였습니다.
- Util 클래스를 생성하여 재사용성을 높였습니다. (추후 location 도메인에서 사용될 수도 있기 때문에)
- hash 디폴트 길이는 7이나, 추후 변경할 수도 있기 때문에 `getGeoHashString`를 오버로딩하였습니다.