### PR TITLE
Feat: 날씨 갱신 API 추가 및 날씨 조회 API 수정

### DIFF
--- a/src/main/java/com/flab/dduikka/common/util/DateTimeUtil.java
+++ b/src/main/java/com/flab/dduikka/common/util/DateTimeUtil.java
@@ -3,10 +3,16 @@ package com.flab.dduikka.common.util;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class DateTimeUtil {
+
+	public LocalDateTime setMinutesToZero(LocalDateTime localDateTime) {
+		return localDateTime.withMinute(0).withSecond(0).withNano(0);
+	}
 
 	public String toLocalDateString(LocalDateTime localDateTime) {
 		return localDateTime.toLocalDate().format(DateTimeFormatter.ofPattern("yyyyMMdd"));

--- a/src/main/java/com/flab/dduikka/domain/weather/api/WeatherController.java
+++ b/src/main/java/com/flab/dduikka/domain/weather/api/WeatherController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.flab.dduikka.domain.weather.application.WeatherService;
+import com.flab.dduikka.domain.weather.dto.WeatherAddRequestDTO;
 import com.flab.dduikka.domain.weather.dto.WeatherRequestDTO;
 import com.flab.dduikka.domain.weather.dto.WeatherResponseDTO;
 

--- a/src/main/java/com/flab/dduikka/domain/weather/application/WeatherService.java
+++ b/src/main/java/com/flab/dduikka/domain/weather/application/WeatherService.java
@@ -1,63 +1,45 @@
 package com.flab.dduikka.domain.weather.application;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.flab.dduikka.common.util.GeoHashUtil;
-import com.flab.dduikka.domain.weather.client.WeatherClient;
 import com.flab.dduikka.domain.weather.domain.Weather;
+import com.flab.dduikka.domain.weather.dto.WeatherAddRequestDTO;
 import com.flab.dduikka.domain.weather.dto.WeatherRequestDTO;
 import com.flab.dduikka.domain.weather.dto.WeatherResponseDTO;
 import com.flab.dduikka.domain.weather.exception.WeatherException;
 import com.flab.dduikka.domain.weather.repository.WeatherRepository;
 
-import feign.FeignException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class WeatherService {
 
-	private final Integer advanceMinutes;
-	private final List<WeatherClient> weatherClients;
 	private final WeatherRepository weatherRepository;
 
-	@Autowired
-	public WeatherService
-		(
-			@Value("${weather.advance-minutes}") Integer advanceMinutes,
-			List<WeatherClient> weatherClients,
-			WeatherRepository weatherRepository
-		) {
-		this.advanceMinutes = advanceMinutes;
-		this.weatherClients = weatherClients;
-		this.weatherRepository = weatherRepository;
-	}
-
+	@Transactional(readOnly = true)
 	public WeatherResponseDTO findWeather(WeatherRequestDTO request) {
 		String geoHash = GeoHashUtil.getGeoHashString(request.getLatitude(), request.getLongitude());
-		LocalDateTime advancedForecastRequestTime = advanceForecastRequestTime(request.getForecastDatetime());
 		Weather foundWeather = weatherRepository.findWeatherByIdAndForecastDatetime(geoHash,
-				advancedForecastRequestTime)
+				request.getForecastDatetime())
 			.orElseThrow(
 				() -> new WeatherException.WeatherNotFoundException("해당 위치에 대한 날씨가 존재하지 않습니다. weatherId: " + geoHash));
 		return WeatherResponseDTO.from(foundWeather);
 	}
 
-	public WeatherResponseDTO getWeather(LocalDateTime dateTime, String latitude, String longitude, String cityCode) {
-		dateTime = dateTime.minusMinutes(10);
-		for (WeatherClient weatherClient : weatherClients) {
-			try {
-				return WeatherResponseDTO.from(weatherClient.getWeather(dateTime, latitude, longitude, cityCode));
-			} catch (FeignException | WeatherException e) {
-				log.error("날씨 API 요청 중 에러 발생 : {}", e.getMessage());
-			}
-		}
-		throw new WeatherException.ExternalAPIException("외부 API에서 오류가 발생하였습니다.");
+	@Transactional(readOnly = true)
+	public boolean existWeather(WeatherAddRequestDTO request) {
+		String geoHash = GeoHashUtil.getGeoHashString(request.getLatitude(), request.getLongitude());
+		return weatherRepository.findWeatherByIdAndForecastDatetime(geoHash, request.getForecastDatetime()).isPresent();
+	}
+
+	@Transactional
+	public void addWeather(Weather weather) {
+		weatherRepository.addWeather(weather);
 	}
 
 	/**

--- a/src/main/java/com/flab/dduikka/domain/weather/dto/AccuWeatherClientResponseDTO.java
+++ b/src/main/java/com/flab/dduikka/domain/weather/dto/AccuWeatherClientResponseDTO.java
@@ -1,7 +1,10 @@
 package com.flab.dduikka.domain.weather.dto;
 
+import java.time.LocalDateTime;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.flab.dduikka.common.util.DateTimeUtil;
+import com.flab.dduikka.common.util.GeoHashUtil;
 import com.flab.dduikka.domain.location.domain.Location;
 import com.flab.dduikka.domain.weather.domain.Weather;
 
@@ -29,12 +32,14 @@ public class AccuWeatherClientResponseDTO {
 
 	public static Weather from(AccuWeatherClientResponseDTO response, Location location) {
 		return Weather.builder()
+			.weatherId(GeoHashUtil.getGeoHashString(location.getLatitude(), location.getLongitude()))
 			.forecastDateTime(DateTimeUtil.toLocalDateTime(response.getDateTime()))
 			.temperature(response.getTemperature().getValue())
 			.relativeHumidity(response.getRelativeHumidity())
 			.rainfall(response.getRain().getValue())
 			.snowfall(response.getSnow().getValue())
 			.location(location)
+			.createdAt(LocalDateTime.now())
 			.build();
 	}
 

--- a/src/main/java/com/flab/dduikka/domain/weather/dto/WeatherAddRequestDTO.java
+++ b/src/main/java/com/flab/dduikka/domain/weather/dto/WeatherAddRequestDTO.java
@@ -8,19 +8,19 @@ import java.time.LocalDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-public class WeatherRequestDTO {
+public class WeatherAddRequestDTO {
 	@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSS")
-	private LocalDateTime forecastDatetime;
+	private LocalDateTime forecastDatetime; // 현재시간
 	private String latitude;
 	private String longitude;
+	private String cityCode;
 
-	public WeatherRequestDTO(LocalDateTime forecastDatetime, String latitude, String longitude) {
+	public WeatherAddRequestDTO(LocalDateTime forecastDatetime, String latitude, String longitude, String cityCode) {
 		this.forecastDatetime = advanceTimeAndSetMintuesToZero(forecastDatetime, ADVANCED_TIME.getValue());
 		this.latitude = latitude;
 		this.longitude = longitude;
+		this.cityCode = cityCode;
 	}
 }

--- a/src/main/java/com/flab/dduikka/domain/weather/facade/WeatherFacade.java
+++ b/src/main/java/com/flab/dduikka/domain/weather/facade/WeatherFacade.java
@@ -1,0 +1,28 @@
+package com.flab.dduikka.domain.weather.facade;
+
+import org.springframework.stereotype.Service;
+
+import com.flab.dduikka.domain.weather.application.WeatherClientService;
+import com.flab.dduikka.domain.weather.application.WeatherService;
+import com.flab.dduikka.domain.weather.domain.Weather;
+import com.flab.dduikka.domain.weather.dto.WeatherAddRequestDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WeatherFacade {
+
+	private final WeatherService weatherService;
+	private final WeatherClientService weatherClientService;
+
+	public void addWeather(WeatherAddRequestDTO request) {
+		// 현재 시간, 위치 기반으로 날씨 데이터를 조회한다.
+		if (!weatherService.existWeather(request)) {
+			// 외부 API를 통해 실시간 예보 데이터를 조회한다.
+			Weather getWeather = weatherClientService.getWeather(request);
+			// 예보 데이터를 등록한다.
+			weatherService.addWeather(getWeather);
+		}
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -42,6 +42,3 @@ websocket:
     destination:
       prefix: /app
   endpoint: /chats
-
-weather:
-  advance-minutes: 10

--- a/src/test/java/com/flab/dduikka/domain/helper/ApiDocumentationHelper.java
+++ b/src/test/java/com/flab/dduikka/domain/helper/ApiDocumentationHelper.java
@@ -18,6 +18,7 @@ import com.flab.dduikka.domain.vote.api.VoteController;
 import com.flab.dduikka.domain.vote.application.VoteRecordService;
 import com.flab.dduikka.domain.weather.api.WeatherController;
 import com.flab.dduikka.domain.weather.application.WeatherService;
+import com.flab.dduikka.domain.weather.facade.WeatherFacade;
 
 @ExtendWith({RestDocumentationExtension.class})
 @AutoConfigureRestDocs
@@ -44,6 +45,9 @@ public abstract class ApiDocumentationHelper {
 
 	@MockBean
 	protected WeatherService weatherService;
+
+	@MockBean
+	protected WeatherFacade weatherFacade;
 
 	@Autowired
 	protected ObjectMapper objectMapper;

--- a/src/test/java/com/flab/dduikka/domain/helper/IntegrationTestHelper.java
+++ b/src/test/java/com/flab/dduikka/domain/helper/IntegrationTestHelper.java
@@ -1,29 +1,10 @@
 package com.flab.dduikka.domain.helper;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.flab.dduikka.common.encryption.EncryptedMemberIdentifierCache;
-import com.flab.dduikka.domain.login.api.LoginController;
-import com.flab.dduikka.domain.login.application.LoginService;
-
-@WebMvcTest(controllers = {
-	LoginController.class
-})
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class IntegrationTestHelper {
 
-	@Autowired
-	protected MockMvc mockMvc;
-
-	@MockBean
-	protected LoginService loginService;
-
-	@Autowired
-	protected ObjectMapper objectMapper;
-
-	@MockBean
-	protected EncryptedMemberIdentifierCache cachedEncryptor;
 }

--- a/src/test/java/com/flab/dduikka/domain/helper/WebMvcTestHelper.java
+++ b/src/test/java/com/flab/dduikka/domain/helper/WebMvcTestHelper.java
@@ -1,0 +1,29 @@
+package com.flab.dduikka.domain.helper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.dduikka.common.encryption.EncryptedMemberIdentifierCache;
+import com.flab.dduikka.domain.login.api.LoginController;
+import com.flab.dduikka.domain.login.application.LoginService;
+
+@WebMvcTest(controllers = {
+	LoginController.class
+})
+public abstract class WebMvcTestHelper {
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@MockBean
+	protected LoginService loginService;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	@MockBean
+	protected EncryptedMemberIdentifierCache cachedEncryptor;
+}

--- a/src/test/java/com/flab/dduikka/domain/login/api/LoginControllerTest.java
+++ b/src/test/java/com/flab/dduikka/domain/login/api/LoginControllerTest.java
@@ -15,7 +15,7 @@ import org.mockito.BDDMockito;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.flab.dduikka.domain.helper.IntegrationTestHelper;
+import com.flab.dduikka.domain.helper.WebMvcTestHelper;
 import com.flab.dduikka.domain.login.dto.LoginRequestDTO;
 import com.flab.dduikka.domain.login.dto.SessionMember;
 import com.flab.dduikka.domain.login.exception.LoginException;
@@ -23,7 +23,7 @@ import com.flab.dduikka.domain.login.exception.LoginException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpSession;
 
-class LoginControllerTest extends IntegrationTestHelper {
+class LoginControllerTest extends WebMvcTestHelper {
 
 	@Test
 	@DisplayName("로그인 요청을 하면 세션이 발급된다")

--- a/src/test/java/com/flab/dduikka/domain/weather/api/WeatherDocumentationTest.java
+++ b/src/test/java/com/flab/dduikka/domain/weather/api/WeatherDocumentationTest.java
@@ -12,11 +12,13 @@ import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 import com.flab.dduikka.domain.helper.ApiDocumentationHelper;
 import com.flab.dduikka.domain.location.domain.Location;
 import com.flab.dduikka.domain.weather.domain.Weather;
+import com.flab.dduikka.domain.weather.dto.WeatherAddRequestDTO;
 import com.flab.dduikka.domain.weather.dto.WeatherRequestDTO;
 import com.flab.dduikka.domain.weather.dto.WeatherResponseDTO;
 
@@ -64,6 +66,34 @@ class WeatherDocumentationTest extends ApiDocumentationHelper {
 					fieldWithPath("statusCode").description("결과코드"),
 					fieldWithPath("statusCodeValue").description("결과값")
 				)))
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("날씨를 저장한다")
+	void addWeather() throws Exception {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		WeatherAddRequestDTO request = new WeatherAddRequestDTO(now, "55", "127", null);
+		doNothing().when(weatherFacade).addWeather(request);
+
+		// when
+		mockMvc.perform(
+				RestDocumentationRequestBuilders
+					.post("/weathers")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request)))
+			.andDo(print())
+			.andDo(document("weathers/addWeather",
+				preprocessRequest(prettyPrint()),
+				preprocessResponse(prettyPrint()),
+				requestFields(
+					fieldWithPath("forecastDatetime").description("예보 요청시간"),
+					fieldWithPath("latitude").description("위도"),
+					fieldWithPath("longitude").description("경도"),
+					fieldWithPath("cityCode").description("도시위치 (아큐웨더용)")
+				)
+			))
 			.andExpect(status().isOk());
 	}
 }

--- a/src/test/java/com/flab/dduikka/domain/weather/application/WeatherServiceTest.java
+++ b/src/test/java/com/flab/dduikka/domain/weather/application/WeatherServiceTest.java
@@ -1,24 +1,24 @@
 package com.flab.dduikka.domain.weather.application;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.BDDAssertions.*;
 import static org.assertj.core.api.SoftAssertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.flab.dduikka.common.util.DateTimeUtil;
 import com.flab.dduikka.domain.location.domain.Location;
-import com.flab.dduikka.domain.weather.client.WeatherClient;
 import com.flab.dduikka.domain.weather.domain.Weather;
+import com.flab.dduikka.domain.weather.dto.WeatherAddRequestDTO;
 import com.flab.dduikka.domain.weather.dto.WeatherRequestDTO;
 import com.flab.dduikka.domain.weather.dto.WeatherResponseDTO;
 import com.flab.dduikka.domain.weather.exception.WeatherException;
@@ -27,18 +27,10 @@ import com.flab.dduikka.domain.weather.repository.WeatherRepository;
 @ExtendWith(MockitoExtension.class)
 class WeatherServiceTest {
 
+	@InjectMocks
 	private WeatherService weatherService;
+	@Mock
 	private WeatherRepository weatherRepository;
-	private List<WeatherClient> weatherClientList;
-
-	@BeforeEach
-	void setUp() {
-		// Integer, String이 mocking 불가하기 때문에 setup을 활용하여 빈 생성 및 주입
-		WeatherClient weatherClient = Mockito.mock(WeatherClient.class);
-		weatherClientList = Collections.singletonList(weatherClient);
-		weatherRepository = Mockito.mock(WeatherRepository.class);
-		weatherService = new WeatherService(10, weatherClientList, weatherRepository);
-	}
 
 	@Test
 	@DisplayName("날씨를 조회한다")
@@ -84,7 +76,7 @@ class WeatherServiceTest {
 			new WeatherRequestDTO(now, "55", "127");
 
 		// when, then
-		assertThatThrownBy(() -> weatherService.findWeather(request))
+		thenThrownBy(() -> weatherService.findWeather(request))
 			.isInstanceOf(WeatherException.WeatherNotFoundException.class)
 			.hasMessageContaining("해당 위치에 대한 날씨가 존재하지 않습니다");
 	}

--- a/src/test/java/com/flab/dduikka/domain/weather/client/AccuWeatherClientTest.java
+++ b/src/test/java/com/flab/dduikka/domain/weather/client/AccuWeatherClientTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.flab.dduikka.common.util.DateTimeUtil;
+import com.flab.dduikka.common.util.GeoHashUtil;
 import com.flab.dduikka.domain.helper.JSONFileReader;
 import com.flab.dduikka.domain.location.domain.Location;
 import com.flab.dduikka.domain.weather.domain.Weather;
@@ -78,6 +79,7 @@ class AccuWeatherClientTest {
 		LocalDateTime localDateTime = LocalDateTime.now();
 		Weather weather =
 			Weather.builder()
+				.weatherId(GeoHashUtil.getGeoHashString(location.getLatitude(), location.getLongitude()))
 				.forecastDateTime(DateTimeUtil.toLocalDateTime("2024-04-26T22:00:00+09:00"))
 				.temperature(15.3)
 				.relativeHumidity(61)

--- a/src/test/java/com/flab/dduikka/domain/weather/dto/AccuWeatherFeignClientResponseTest.java
+++ b/src/test/java/com/flab/dduikka/domain/weather/dto/AccuWeatherFeignClientResponseTest.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.dduikka.common.util.DateTimeUtil;
+import com.flab.dduikka.common.util.GeoHashUtil;
 import com.flab.dduikka.domain.location.domain.Location;
 import com.flab.dduikka.domain.weather.domain.Weather;
 
@@ -37,6 +38,7 @@ class AccuWeatherFeignClientResponseTest {
 		Location location = new Location("55", "127");
 		Weather weather =
 			Weather.builder()
+				.weatherId(GeoHashUtil.getGeoHashString(location.getLatitude(), location.getLongitude()))
 				.forecastDateTime(DateTimeUtil.toLocalDateTime("2024-04-26T22:00:00+09:00"))
 				.temperature(15.3)
 				.relativeHumidity(61)

--- a/src/test/java/com/flab/dduikka/domain/weather/facade/WeatherFacadeTest.java
+++ b/src/test/java/com/flab/dduikka/domain/weather/facade/WeatherFacadeTest.java
@@ -1,0 +1,130 @@
+package com.flab.dduikka.domain.weather.facade;
+
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.flab.dduikka.common.util.GeoHashUtil;
+import com.flab.dduikka.domain.helper.IntegrationTestHelper;
+import com.flab.dduikka.domain.location.domain.Location;
+import com.flab.dduikka.domain.weather.application.WeatherClientService;
+import com.flab.dduikka.domain.weather.application.WeatherService;
+import com.flab.dduikka.domain.weather.domain.Weather;
+import com.flab.dduikka.domain.weather.dto.WeatherAddRequestDTO;
+import com.flab.dduikka.domain.weather.exception.WeatherException;
+import com.flab.dduikka.domain.weather.repository.WeatherRepository;
+
+class WeatherFacadeTest extends IntegrationTestHelper {
+
+	@Autowired
+	private WeatherFacade weatherFacade;
+
+	@Autowired
+	private WeatherService weatherService;
+
+	@MockBean
+	private WeatherClientService weatherClientService;
+
+	@Autowired
+	private WeatherRepository weatherRepository;
+
+	@Test
+	@DisplayName("날씨가 있으면 프로세스가 정상 종료된다.")
+	void whenFindWeather_ThenCompleteProcess() {
+		// given
+		String latitude = "55";
+		String longitude = "127";
+		LocalDateTime now = LocalDateTime.now();
+		Location location = new Location(latitude, longitude);
+
+		WeatherAddRequestDTO request
+			= new WeatherAddRequestDTO(now, latitude, longitude, null);
+
+		Weather newWeather = Weather.builder()
+			.weatherId(GeoHashUtil.getGeoHashString(latitude, longitude))
+			.forecastDateTime(request.getForecastDatetime())
+			.temperature(32.0)
+			.relativeHumidity(70)
+			.rainfall(0.0)
+			.snowfall(0.0)
+			.location(location)
+			.createdAt(now)
+			.build();
+
+		weatherService.addWeather(newWeather);
+
+		// when
+		weatherFacade.addWeather(request);
+
+		// then
+		BDDMockito.then(weatherClientService).should(never()).getWeather(any());
+	}
+
+	@Test
+	@DisplayName("날씨가 DB에 존재하지 않아 날씨 API 호출 시 에러가 발생하면 예외가 발생한다.")
+	void whenNotFoundWeatherAndApiCalled_thenThrowsException() {
+		// given
+		String latitude = "55";
+		String longitude = "127";
+		LocalDateTime now = LocalDateTime.now();
+
+		WeatherAddRequestDTO request
+			= new WeatherAddRequestDTO(now, latitude, longitude, null);
+
+		given(weatherClientService.getWeather(any())).willThrow(WeatherException.ExternalAPIException.class);
+
+		// when, then
+		thenThrownBy(() -> weatherFacade.addWeather(request))
+			.isInstanceOf(WeatherException.ExternalAPIException.class);
+	}
+
+	@Test
+	@DisplayName("날씨가 DB에 존재하지 않아 날씨를 저장한다.")
+	void whenNotFoundWeather_thenAddWeather() {
+		// given
+		String latitude = "55";
+		String longitude = "127";
+		LocalDateTime now = LocalDateTime.now();
+		Location location = new Location(latitude, longitude);
+
+		WeatherAddRequestDTO request
+			= new WeatherAddRequestDTO(now, latitude, longitude, null);
+
+		Weather mockWeather = Weather.builder()
+			.weatherId(GeoHashUtil.getGeoHashString(latitude, longitude))
+			.forecastDateTime(request.getForecastDatetime())
+			.temperature(32.0)
+			.relativeHumidity(70)
+			.rainfall(0.0)
+			.snowfall(0.0)
+			.location(location)
+			.createdAt(now)
+			.build();
+
+		given(weatherClientService.getWeather(any())).willReturn(mockWeather);
+
+		// when
+		weatherFacade.addWeather(request);
+
+		// then
+		Weather foundWeather = weatherRepository.findWeatherByIdAndForecastDatetime(
+			mockWeather.getWeatherId(), mockWeather.getForecastDateTime()).get();
+
+		assertSoftly(softly -> {
+			softly.assertThat(foundWeather.getWeatherId()).isEqualTo(mockWeather.getWeatherId());
+			softly.assertThat(foundWeather.getForecastDateTime()).isEqualTo(mockWeather.getForecastDateTime());
+			softly.assertThat(foundWeather.getRainfall()).isEqualTo(mockWeather.getRainfall());
+			softly.assertThat(foundWeather.getSnowfall()).isEqualTo(mockWeather.getSnowfall());
+			softly.assertThat(foundWeather.getRelativeHumidity()).isEqualTo(mockWeather.getRelativeHumidity());
+			softly.assertThat(foundWeather.getTemperature()).isEqualTo(mockWeather.getTemperature());
+		});
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -47,6 +47,3 @@ jasypt:
   encryptor:
     password: test
 
-weather:
-  advance-minutes: 10
-


### PR DESCRIPTION
[세부내용]
- 날씨 갱신 API를 추가하였습니다. 
- application layer와 repository layer를 테스트하기 위한 `IntergrationTest`를 추가하였습니다. 기존 IntergrationTest는 WebMvc에 국한된 테스트라 헬퍼 클래스명을 변경하였습니다.
- 날씨 데이터는 매시간마다 갱신되기 때문에 조회 조건 단순화를 위해 초기화 + 시간을 앞당기는 메소드를 추가하였습니다.
    - ex) 17시 18분 53초 -> 17시 8분 53초 -> (최종) 17시 0분 0초