### PR TITLE
Fix: 일시 변환 기능 수정

### DIFF
--- a/src/main/java/com/flab/dduikka/common/util/DateTimeUtil.java
+++ b/src/main/java/com/flab/dduikka/common/util/DateTimeUtil.java
@@ -11,7 +11,8 @@ import lombok.experimental.UtilityClass;
 public class DateTimeUtil {
 
 	public LocalDateTime setMinutesToZero(LocalDateTime localDateTime) {
-		return localDateTime.withMinute(0).withSecond(0);
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:00:00");
+		return LocalDateTime.parse(localDateTime.format(formatter));
 	}
 
 	public LocalDateTime advanceTimeAndSetMintuesToZero(LocalDateTime localDateTime, int minusMinutes) {

--- a/src/test/java/com/flab/dduikka/common/util/DateTimeUtilTest.java
+++ b/src/test/java/com/flab/dduikka/common/util/DateTimeUtilTest.java
@@ -1,5 +1,6 @@
 package com.flab.dduikka.common.util;
 
+import static com.flab.dduikka.common.util.DateTimeUtil.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
@@ -14,7 +15,7 @@ class DateTimeUtilTest {
 	void whenToLocalDateString_thenReturnLocalDateString() {
 		LocalDateTime localDateTime =
 			LocalDateTime.of(2024, 4, 20, 10, 30);
-		String localDateString = DateTimeUtil.toLocalDateString(localDateTime);
+		String localDateString = toLocalDateString(localDateTime);
 		assertThat(localDateString).isEqualTo("20240420");
 	}
 
@@ -23,7 +24,7 @@ class DateTimeUtilTest {
 	void whenToLocalDateString_thenReturnLocalDateString_fail() {
 		LocalDateTime localDateTime =
 			LocalDateTime.of(2024, 5, 20, 10, 30);
-		String localDateString = DateTimeUtil.toLocalDateString(localDateTime);
+		String localDateString = toLocalDateString(localDateTime);
 		assertThat(localDateString).isNotEqualTo("20240420");
 	}
 
@@ -32,7 +33,7 @@ class DateTimeUtilTest {
 	void whenToLocalTimeString_thenReturnLocalTimeString() {
 		LocalDateTime localDateTime =
 			LocalDateTime.of(2024, 4, 20, 05, 30);
-		String localTimeString = DateTimeUtil.toLocalTimeString(localDateTime);
+		String localTimeString = toLocalTimeString(localDateTime);
 		assertThat(localTimeString).isEqualTo("0530");
 	}
 
@@ -41,7 +42,7 @@ class DateTimeUtilTest {
 	void whenToLocalTimeString_thenReturnLocalTimeString_fail() {
 		LocalDateTime localDateTime =
 			LocalDateTime.of(2024, 4, 20, 15, 30);
-		String localTimeString = DateTimeUtil.toLocalTimeString(localDateTime);
+		String localTimeString = toLocalTimeString(localDateTime);
 		assertThat(localTimeString).isNotEqualTo("0530");
 	}
 
@@ -49,7 +50,7 @@ class DateTimeUtilTest {
 	@DisplayName("localdateTime String을 LocalDateTime 타입으로 변환한다")
 	void whenToLocalDateTime_thenReturnsLocalDateTime() {
 		String localDateTime = "2024-04-25T18:00:00+09:00";
-		LocalDateTime localDate = DateTimeUtil.toLocalDateTime(localDateTime);
+		LocalDateTime localDate = toLocalDateTime(localDateTime);
 		assertThat(localDate)
 			.isEqualTo(LocalDateTime.of(2024, 04, 25, 18, 00, 00));
 	}
@@ -58,7 +59,7 @@ class DateTimeUtilTest {
 	@DisplayName("localdateTime String을 LocalDateTime 타입으로 변환한다_fail")
 	void whenToLocalDateTime_thenReturnsLocalDateTime_fail() {
 		String localDateTime = "2024-05-25T18:00:00+09:00";
-		LocalDateTime localDate = DateTimeUtil.toLocalDateTime(localDateTime);
+		LocalDateTime localDate = toLocalDateTime(localDateTime);
 		assertThat(localDate)
 			.isNotEqualTo(LocalDateTime.of(2024, 04, 25, 18, 00, 00));
 	}
@@ -68,7 +69,7 @@ class DateTimeUtilTest {
 	void whenToLocalDateTimeGivenTwoString_thenReturnsLocalDateTime() {
 		String localDate = "20240425";
 		String localTime = "0710";
-		LocalDateTime localDateTime = DateTimeUtil.toLocalDateTime(localDate, localTime);
+		LocalDateTime localDateTime = toLocalDateTime(localDate, localTime);
 		assertThat(localDateTime)
 			.isEqualTo(LocalDateTime.of(2024, 04, 25, 07, 10, 00));
 	}
@@ -78,9 +79,64 @@ class DateTimeUtilTest {
 	void whenToLocalDateTimeGivenTwoString_thenReturnsLocalDateTime_fail() {
 		String localDate = "20240425";
 		String localTime = "0710";
-		LocalDateTime localDateTime = DateTimeUtil.toLocalDateTime(localDate, localTime);
+		LocalDateTime localDateTime = toLocalDateTime(localDate, localTime);
 		assertThat(localDateTime)
 			.isNotEqualTo(LocalDateTime.of(2024, 05, 25, 07, 10, 00));
+	}
+
+	@Test
+	@DisplayName("분초를 초기화한다_success")
+	void setMinutesToZero_success() {
+		// given
+		int year = 2024;
+		int month = 10;
+		int dayOfMonth = 29;
+		int hour = 16;
+		int minute = 43;
+		LocalDateTime localDateTime = LocalDateTime.of(year, month, dayOfMonth, hour, minute, 20, 23);
+
+		// when
+		LocalDateTime changedLocalDateTime = setMinutesToZero(localDateTime);
+
+		// then
+		assertThat(changedLocalDateTime).isEqualTo(LocalDateTime.of(year, month, dayOfMonth, hour, 0, 0));
+	}
+
+	@Test
+	@DisplayName("minusMinutes만큼 현재 시간에서 빼고 분초를 초기화한다_성공")
+	void advanceTimeAndSetMintuesToZero_success() {
+		// given
+		int year = 2024;
+		int month = 10;
+		int dayOfMonth = 29;
+		int hour = 16;
+		int minute = 43;
+		LocalDateTime localDateTime = LocalDateTime.of(year, month, dayOfMonth, hour, minute, 20, 23);
+
+		// when
+		LocalDateTime advancedTime = advanceTimeAndSetMintuesToZero(localDateTime, 10);
+
+		// then
+		assertThat(advancedTime).isEqualTo(LocalDateTime.of(year, month, dayOfMonth, hour, 0, 0));
+	}
+
+	@Test
+	@DisplayName("현재 시간이 4시일 때 3시로 시간을 앞당긴다_성공")
+	void advanceTimeAndSetMintuesToZero2_success() {
+		// given
+		int year = 2024;
+		int month = 10;
+		int dayOfMonth = 29;
+		int hour = 16;
+		int minute = 4;
+		LocalDateTime localDateTime = LocalDateTime.of(year, month, dayOfMonth, hour, minute, 20, 23);
+
+		// when
+		LocalDateTime advancedTime = advanceTimeAndSetMintuesToZero(localDateTime, 10);
+		System.out.println(advancedTime);
+
+		// then
+		assertThat(advancedTime).isEqualTo(LocalDateTime.of(year, month, dayOfMonth, hour - 1, 0, 0));
 	}
 
 }


### PR DESCRIPTION
# Fix: 일시 변환 기능 수정
Fix: 일시 변환 기능 수정
<!-- 가장 대표적인 작업 내용 -->

## 기능 설명
<!-- 기능에 대한 구체적인 설명 -->
이전 일시 변환 기능을 밀리초가 포함되는 현상이 발생하였다. 즉, 밀리초 차이로 다른 일시로 인식할 가능성이 있어 `DateTimeFormat`을 사용하여 밀리초부터 `truncate`한다.

## 이슈
closed : #87 