### PR TITLE
Feat: 테스트 DB 초기화 클래스 생성 및 반영

### DIFF
--- a/src/test/java/com/flab/dduikka/common/config/DatabaseCleaner.java
+++ b/src/test/java/com/flab/dduikka/common/config/DatabaseCleaner.java
@@ -1,0 +1,72 @@
+package com.flab.dduikka.common.config;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.PreparedStatementCallback;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class DatabaseCleaner {
+
+	private final List<String> tables = new ArrayList<>();
+
+	@Autowired
+	private NamedParameterJdbcTemplate jdbcTemplate;
+
+	@SuppressWarnings("unchecked")
+	@PostConstruct
+	public void findDatabaseTableNames() {
+		List<TableInfo> tableInfos = jdbcTemplate.query("SHOW TABLES", rowMapper());
+		for (TableInfo tableInfo : tableInfos) {
+			tables.add(tableInfo.getTableName());
+		}
+	}
+
+	private void truncate() {
+		CustomPreparedStatementCallback statementCallback = new CustomPreparedStatementCallback();
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = :flag", Map.of("flag", 0), statementCallback);
+		for (String tableName : tables) {
+			jdbcTemplate.execute(String.format("TRUNCATE TABLE %s", tableName), statementCallback);
+		}
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = :flag", Map.of("flag", 1), statementCallback);
+	}
+
+	@Transactional
+	public void clear() {
+		truncate();
+	}
+
+	private RowMapper<TableInfo> rowMapper() {
+		return (rs, rowNum) -> new TableInfo(rs.getString("Tables_in_test"));
+	}
+
+	class CustomPreparedStatementCallback implements PreparedStatementCallback<Boolean> {
+		@Override
+		public Boolean doInPreparedStatement(PreparedStatement ps) throws SQLException, DataAccessException {
+			return ps.execute();
+		}
+	}
+
+	class TableInfo {
+		private String tableName;
+
+		public TableInfo(String tableName) {
+			this.tableName = tableName;
+		}
+
+		public String getTableName() {
+			return tableName;
+		}
+	}
+}

--- a/src/test/java/com/flab/dduikka/common/config/DatabaseClearExtension.java
+++ b/src/test/java/com/flab/dduikka/common/config/DatabaseClearExtension.java
@@ -1,0 +1,18 @@
+package com.flab.dduikka.common.config;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseClearExtension implements BeforeEachCallback {
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		DatabaseCleaner databaseCleaner = getDataCleaner(context);
+		databaseCleaner.clear();
+	}
+
+	private DatabaseCleaner getDataCleaner(ExtensionContext extensionContext) {
+		return SpringExtension.getApplicationContext(extensionContext)
+			.getBean(DatabaseCleaner.class);
+	}
+}

--- a/src/test/java/com/flab/dduikka/domain/helper/IntegrationTestHelper.java
+++ b/src/test/java/com/flab/dduikka/domain/helper/IntegrationTestHelper.java
@@ -1,7 +1,11 @@
 package com.flab.dduikka.domain.helper;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import com.flab.dduikka.common.config.DatabaseClearExtension;
+
+@ExtendWith(DatabaseClearExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class IntegrationTestHelper {
 


### PR DESCRIPTION
# 테스트 DB 초기화 클래스 생성 및 반영
<!-- 가장 대표적인 작업 내용 -->

## 기능 설명
<!-- 기능에 대한 구체적인 설명 -->
테스트 격리를 위해 테스트 DB 초기화 클래스를 구현했습니다. 빈 생성 이후, `show table` 쿼리로 table list를 저장한 뒤 테스트 메소드 실행 전마다 `truncate` 쿼리가 실행됩니다.

### 관련 이슈
<!-- 추가 필요한 정보 -->
closed #93 